### PR TITLE
add enums for wait strategies and configuration properties; refactor BasePage to use ExplicitWaitFactory

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -26,3 +26,12 @@ ReadPropertyFile.java:
   - Throws clear errors if a requested setting does not exist.
   - Uses logging for better traceability and debugging.
 
+ExplicitWaitFactory.java:
+ - Centralizes explicit wait logic for different WaitStrategy types.
+ - Improves code reuse and reliability by abstracting wait conditions.
+ - Throws an exception for invalid strategies, ensuring robustness.
+
+WaitStrategy.java & ConfigProperties.java:
+ - Defines enums for wait strategies and configuration properties.
+ - Improves type safety and code clarity by using enums instead of strings.
+ - Makes the code more maintainable and less error-prone.

--- a/src/test/java/org/myframeworks/constants/FrameworkConstants.java
+++ b/src/test/java/org/myframeworks/constants/FrameworkConstants.java
@@ -16,9 +16,14 @@ public final class FrameworkConstants {
 
     private static final String RESOURCE_PATH = System.getProperty("user.dir") + "/src/test/resources/";
     private static final String CONFIG_FILE_PATH = RESOURCE_PATH + "config/config.properties";
+    private static final int EXPLICIT_WAIT = 10;
 
 
     public static String getConfigFilePath() {
         return CONFIG_FILE_PATH;
+    }
+
+    public static int getExplicitWait() {
+        return EXPLICIT_WAIT;
     }
 }

--- a/src/test/java/org/myframeworks/driver/Driver.java
+++ b/src/test/java/org/myframeworks/driver/Driver.java
@@ -1,9 +1,9 @@
 package org.myframeworks.driver;
 
+import org.myframeworks.enums.ConfigProperties;
 import org.myframeworks.utils.ReadPropertyFile;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
-
 import java.util.Objects;
 
 import static org.myframeworks.driver.DriverManager.*;
@@ -17,7 +17,7 @@ public final class Driver {
             setDriver(driver);
             WebDriver localDriver = getDriver();
             localDriver.manage().window().maximize();
-            localDriver.get(ReadPropertyFile.getProperty("url"));
+            localDriver.get(ReadPropertyFile.getProperty(ConfigProperties.URL.name().toLowerCase()));
         }
     }
 

--- a/src/test/java/org/myframeworks/enums/ConfigProperties.java
+++ b/src/test/java/org/myframeworks/enums/ConfigProperties.java
@@ -1,0 +1,5 @@
+package org.myframeworks.enums;
+
+public enum ConfigProperties {
+    URL
+}

--- a/src/test/java/org/myframeworks/enums/WaitStrategy.java
+++ b/src/test/java/org/myframeworks/enums/WaitStrategy.java
@@ -1,0 +1,8 @@
+package org.myframeworks.enums;
+
+public enum WaitStrategy {
+    CLICKABLE,
+    PRESENCE,
+    VISIBLE,
+    NONE,
+}

--- a/src/test/java/org/myframeworks/factories/ExplicitWaitFactory.java
+++ b/src/test/java/org/myframeworks/factories/ExplicitWaitFactory.java
@@ -13,6 +13,9 @@ import static org.myframeworks.driver.DriverManager.getDriver;
 
 public class ExplicitWaitFactory {
 
+    private ExplicitWaitFactory() {
+        // Private constructor to prevent instantiation
+    }
 
     public static WebElement waitForElement(By by, WaitStrategy waitStrategy){
         switch (waitStrategy) {

--- a/src/test/java/org/myframeworks/factories/ExplicitWaitFactory.java
+++ b/src/test/java/org/myframeworks/factories/ExplicitWaitFactory.java
@@ -1,0 +1,34 @@
+package org.myframeworks.factories;
+
+import org.myframeworks.constants.FrameworkConstants;
+import org.myframeworks.enums.WaitStrategy;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+
+import static org.myframeworks.driver.DriverManager.getDriver;
+
+public class ExplicitWaitFactory {
+
+
+    public static WebElement waitForElement(By by, WaitStrategy waitStrategy){
+        switch (waitStrategy) {
+            case CLICKABLE:
+                return new WebDriverWait(getDriver(), Duration.ofSeconds(FrameworkConstants.getExplicitWait()))
+                        .until(ExpectedConditions.elementToBeClickable(by));
+            case PRESENCE:
+                return new WebDriverWait(getDriver(), Duration.ofSeconds(FrameworkConstants.getExplicitWait()))
+                        .until(ExpectedConditions.presenceOfElementLocated(by));
+            case VISIBLE:
+                return new WebDriverWait(getDriver(), Duration.ofSeconds(FrameworkConstants.getExplicitWait()))
+                        .until(ExpectedConditions.visibilityOfElementLocated(by));
+            case NONE:
+                return getDriver().findElement(by);
+            default:
+                throw new IllegalArgumentException("Invalid wait strategy: " + waitStrategy);
+        }
+    }
+}

--- a/src/test/java/org/myframeworks/pages/BasePage.java
+++ b/src/test/java/org/myframeworks/pages/BasePage.java
@@ -1,46 +1,23 @@
 package org.myframeworks.pages;
 
+import org.myframeworks.enums.WaitStrategy;
+import org.myframeworks.factories.ExplicitWaitFactory;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.time.Duration;
 import static org.myframeworks.driver.DriverManager.getDriver;
 
 public class BasePage {
 
-    private final WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(10));
-
-    public void waitForElementToBeClickable(By by){
-        wait.until(ExpectedConditions.elementToBeClickable(by));
+    public void clickElement(By by, WaitStrategy waitStrategy) {
+        WebElement element = ExplicitWaitFactory.waitForElement(by, waitStrategy);
+        element.click();
     }
 
-    public void waitForElementToBePresent(By by){
-        wait.until(ExpectedConditions.presenceOfElementLocated(by));
-    }
-
-    public void clickElement(By by){
-        try {
-            waitForElementToBeClickable(by);
-            WebElement element = getDriver().findElement(by);
-            element.click();
-        } catch (Exception e) {
-            System.err.println("Failed to click element: " + by + " - " + e.getMessage());
-            throw e;
-        }
-    }
-
-    public void enterText(By by, String text){
-        try {
-            waitForElementToBePresent(by);
-            WebElement element = getDriver().findElement(by);
+    public void enterText(By by, String text, WaitStrategy waitStrategy) {
+            WebElement element = ExplicitWaitFactory.waitForElement(by, waitStrategy);
             element.clear();
             element.sendKeys(text);
-        } catch (Exception e) {
-            System.err.println("Failed to enter text in element: " + by + " - " + e.getMessage());
-            throw e;
-        }
     }
 
     public String getPageTitle() {

--- a/src/test/java/org/myframeworks/pages/OrangeHRMHomePage.java
+++ b/src/test/java/org/myframeworks/pages/OrangeHRMHomePage.java
@@ -1,5 +1,6 @@
 package org.myframeworks.pages;
 
+import org.myframeworks.enums.WaitStrategy;
 import org.openqa.selenium.By;
 
 
@@ -11,16 +12,16 @@ import org.openqa.selenium.By;
 public class OrangeHRMHomePage extends BasePage {
 
     private final By userDropdownIcon = By.xpath("//i[contains(@class, 'userdropdown-icon')]");
-    private final By logoutButton = By.xpath("//a[text()='Logout']");
+    private final By logoutLink = By.xpath("//a[text()='Logout']");
 
 
     public OrangeHRMHomePage clickUserDropdownIcon() {
-        clickElement(userDropdownIcon);
+        clickElement(userDropdownIcon, WaitStrategy.CLICKABLE);
         return this;
     }
 
     public OrangeHRMLoginPage clickLogoutButton() {
-        clickElement(logoutButton);
+        clickElement(logoutLink, WaitStrategy.CLICKABLE);
         return new OrangeHRMLoginPage();
     }
 

--- a/src/test/java/org/myframeworks/pages/OrangeHRMLoginPage.java
+++ b/src/test/java/org/myframeworks/pages/OrangeHRMLoginPage.java
@@ -1,5 +1,6 @@
 package org.myframeworks.pages;
 
+import org.myframeworks.enums.WaitStrategy;
 import org.openqa.selenium.By;
 
 public class OrangeHRMLoginPage extends BasePage{
@@ -9,17 +10,17 @@ public class OrangeHRMLoginPage extends BasePage{
     private final By loginButton = By.xpath("//button[@type='submit']");
 
     public OrangeHRMLoginPage enterUsername(String username) {
-        enterText(usernameField, username);
+        enterText(usernameField, username, WaitStrategy.PRESENCE);
         return this;
     }
 
     public OrangeHRMLoginPage enterPassword(String password) {
-        enterText(passwordField, password);
+        enterText(passwordField, password, WaitStrategy.PRESENCE);
         return this;
     }
 
     public OrangeHRMHomePage clickLoginButton() {
-        clickElement(loginButton);
+        clickElement(loginButton, WaitStrategy.CLICKABLE);
         return new OrangeHRMHomePage();
     }
 


### PR DESCRIPTION

Refactored the waitForElement method in ExplicitWaitFactory.java to directly return the result from each switch case. This removes unnecessary variable assignments and unreachable code, improving code clarity and eliminating compiler warnings. No changes were made to the functional behavior.